### PR TITLE
Added Elastic Search's New Relic quickstart link

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -24,7 +24,9 @@ include::{include_path}/plugin_header.asciidoc[]
 This output sends logstash events to New Relic Insights as custom events.
 
 You can learn more about New Relic Insights here:
-https://docs.newrelic.com/docs/insights/new-relic-insights/understanding-insights/new-relic-insights
+https://docs.newrelic.com/docs/insights/new-relic-insights/understanding-insights/new-relic-insights 
+and at:
+https://newrelic.com/instant-observability/elasticsearch
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Newrelic Output Configuration Options


### PR DESCRIPTION
Hey Elastic dev team,

We have many users on our platform who are using Elastic Search and would like to instrument it. We’d love to provide a smooth experience for Elastic Search users who need to use commercial monitoring solutions, such as New Relic. Please see our [documentation here](https://newrelic.com/instant-observability/elasticsearch).

Please consider adding a link for your direct users to provide an option for New Relic.  For your convenience, we have submitted this PR with our proposed content.

Please feel free to let us know if you have any questions or concerns.

Thank you for your consideration.

